### PR TITLE
(Feat): Automate PDF downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Since the data in KSDMA is uploaded as a pdf without a uniform naming convention
 ## Enviroment Variables
 Variable | Description
 ---------|------------
-DAM_WATER_LEVEL_FILE_LOCATION | URL of the KSEB dam data pdf file obtained from KSDMA site (https only)
-IRRIGATION_DAM_WATER_LEVEL_FILE_LOCATION | URL of the irrigation dams data pdf file obtained from KSDMA site (https only)
+KERALA_DAM_WATER_LEVEL_PDF_URI | Webpage where URLs of the KSEB dam data PDFs are hyperlinked. (file obtained from KSDMA site (https only)
 TN_DATA_URL | URL of TN dams data, from AGRISNET
+
 ## API Routes
 Route | Description
 ------|------------
@@ -22,8 +22,9 @@ Route | Description
 /dam/getTNDamData | Returns a JSON containing the status of dams in Tamil Nadu
 
 ## To-do
-- [ ] A HTML crawler to fetch the URL's of the PDF files automatically
+- [x] A HTML crawler to fetch the URL's of the PDF files automatically
 - [x] A efficient way to extract entire date & time from the PDF
 - [ ] Logic to calculate alert level of the dam
 - [ ] Find a better way to get the data preferrably a spreadsheet
 - [ ] Fix Malayalam typo
+- [ ] Reduce processing time.

--- a/crawler.js
+++ b/crawler.js
@@ -1,17 +1,21 @@
 const fetch = require('node-fetch');
 const cheerio = require('cheerio');
 
-module.exports = (source) => new Promise((resolve) => {
-    fetch('https://sdma.kerala.gov.in/dam-water-level/').then(response => response.text()).then(body => {
-        const $ = cheerio.load(body);
-        var link = null;
-        $('div.entry-content ol li').each((i, elem) => {
-            var liTitle = $(elem).text();
-            if (liTitle.toLowerCase().includes(source.toLowerCase())) {
-                var anchorTag = $(elem).children();
-                link = `https://sdma.kerala.gov.in${anchorTag.attr('href')}`;
-            }
-        });
-        resolve(link);
-    });
-});
+module.exports = {
+   
+    getPDF: async function(){
+        var link = [];
+        await fetch(process.env.KERALA_DAM_WATER_LEVEL_PDF_URI).then(response => response.text()).then(body => {
+
+            const $ = cheerio.load(body);
+
+            $('div.entry-content ol li').each((i, elem) => {
+                var anchorTag = $(elem).children();        
+                link.push(`${anchorTag.attr('href')}`);
+            });
+
+        });   
+         
+        return link;    
+    }
+}

--- a/dam.js
+++ b/dam.js
@@ -4,6 +4,7 @@ var pdf_table_extractor = require("pdf-table-extractor");
 const cors = require('cors')
 const tabletojson = require('tabletojson').Tabletojson;
 const wget = require('wget-improved');
+var craw = require('./crawler')
 
 // Function to download file
 const download = (url, dest) => new Promise((resolve, reject) => {
@@ -102,10 +103,12 @@ router.get('/getData', (req, res, next) => {
       on_error(res, error);
     }
   }
+  craw.getPDF().then(data => {
+    download(data[0], "kseb_dam.pdf").then((value) => {
+      pdf_table_extractor("kseb_dam.pdf", success, (error) => on_error(res, error));
+    }, (error) => on_error(res, error));
+  })
 
-  download(process.env.DAM_WATER_LEVEL_FILE_LOCATION, "kseb_dam.pdf").then((value) => {
-    pdf_table_extractor("kseb_dam.pdf", success, (error) => on_error(res, error));
-  }, (error) => on_error(res, error));
 });
 
 router.get('/getIrrigationData', (req, res, next) => {
@@ -146,9 +149,12 @@ router.get('/getIrrigationData', (req, res, next) => {
     }
   }
 
-  download(process.env.IRRIGATION_DAM_WATER_LEVEL_FILE_LOCATION, "irrigation_dam.pdf").then((value) => {
-    pdf_table_extractor("irrigation_dam.pdf", success, (error) => on_error(res, error));
-  }, (error) => on_error(res, error));
+  craw.getPDF().then(data => {
+    download(data[1], "irrigation_dam.pdf").then((value) => {
+      pdf_table_extractor("irrigation_dam.pdf", success, (error) => on_error(res, error));
+    }, (error) => on_error(res, error));
+  })
+
 });
 
 router.get('/getTNDamData', (req, res, next) => {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,13 @@
     "express": "^4.17.1",
     "pdf-table-extractor": "^1.0.3",
     "tabletojson": "^2.0.7",
-    "wget-improved": "^3.2.1"
+    "wget-improved": "^3.2.1",
+    "node-fetch": "2.6.6"
   },
   "devDependencies": {
     "nodemon": "^2.0.13"
+  },
+  "engines": {
+    "node": "14.18.1"
   }
 }


### PR DESCRIPTION
This PR automates the dam data PDF downloads. 

Note: Automation adds computational time by ~3 seconds. This really unnecessary & redundant since it adds an overhead of crawling PDFs links from web-page & downloading for every requests.

A fix would be having a corn job or CI/CD where latest PDFs are updated to a public URL independently.